### PR TITLE
Fixed promise import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.0.5
+
+### Fixed
+
+- `fs/promises` import broken in Node 12+
+
 ## 0.0.4
 
 ### Fixed

--- a/lib/create-remote-cache-retrieve.ts
+++ b/lib/create-remote-cache-retrieve.ts
@@ -1,11 +1,12 @@
 import { RemoteCache } from "@nrwl/workspace/src/tasks-runner/default-tasks-runner";
 import AdmZip from "adm-zip";
 import { promises } from "fs";
-const { writeFile } = promises;
-
 import { join } from "path";
 import { promisify } from "util";
+
 import { SafeRemoteCacheImplementation } from "./types/safe-remote-cache-implementation";
+
+const { writeFile } = promises;
 
 const COMMIT_FILE_EXTENSION = ".commit";
 const COMMIT_FILE_CONTENT = "true";

--- a/lib/create-remote-cache-retrieve.ts
+++ b/lib/create-remote-cache-retrieve.ts
@@ -1,6 +1,8 @@
 import { RemoteCache } from "@nrwl/workspace/src/tasks-runner/default-tasks-runner";
 import AdmZip from "adm-zip";
-import { writeFile } from "fs/promises";
+import { promises } from "fs";
+const { writeFile } = promises;
+
 import { join } from "path";
 import { promisify } from "util";
 import { SafeRemoteCacheImplementation } from "./types/safe-remote-cache-implementation";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nx-remotecache-custom",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Build custom caching for @nrwl/nx in a few lines of code",
   "main": "index.js",
   "typings": "index.d.ts",


### PR DESCRIPTION
Fixes ''Cannot find module 'fs/promises'' in Node 12+. Increased version to 0.0.5 and updated the changelog