### PR TITLE
Introduce read/write setting mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ After this your package is already ready for usage. Publish it to npm (or an int
 | Option       | Environment Variable / .env | Description                                                                                           |
 | ------------ | --------------------------- | ----------------------------------------------------------------------------------------------------- |
 | `name`       | `NXCACHE_NAME`              | Set to provide task runner name for logging. Overrides name provided in implementation.               |
+| `mode`       | `NXCACHE_MODE`              | Set to enable or disable reads and/or writes to remote. Options: `read-write` `read-only` `write-only` `disabled` **Default:** `read-write` |
 | `verbose`    |                             | Set to receive full stack traces whenever errors occur. Best used for debugging. **Default:** `false` |
 | `silent`     |                             | Set to mute success and info logs. **Default:** `false`                                               |
 | `dotenv`     |                             | Set to `false` to disable reading `.env` into `process.env`. **Default:** `true`                      |

--- a/lib/create-custom-runner.ts
+++ b/lib/create-custom-runner.ts
@@ -8,6 +8,31 @@ import { RemoteCacheImplementation } from "./types/remote-cache-implementation";
 
 type DefaultTasksRunner = typeof defaultTasksRunner;
 
+const getReadWriteDisabledStatus = (
+  options: CustomRunnerOptions
+): [boolean, boolean] => {
+  const mode = process.env.NXCACHE_MODE || options.mode;
+  if (!options.silent) {
+    console.info(`Running runner with remoteCache mode: ${mode}`);
+  }
+  switch (mode) {
+    case "disabled":
+      return [true, true];
+    case "read-only":
+      return [false, true];
+    case "write-only":
+      return [true, false];
+    case "read-write":
+    case undefined:
+      return [false, false];
+    default:
+      console.warn(
+        `Unknown mode configured, falling back to 'read-write': '${mode}'`
+      );
+      return [false, false];
+  }
+};
+
 const createRemoteCache = (
   implementation: Promise<RemoteCacheImplementation>,
   options: CustomRunnerOptions
@@ -16,10 +41,11 @@ const createRemoteCache = (
     implementation,
     options
   );
+  const [readDisabled, writeDisabled] = getReadWriteDisabledStatus(options);
 
   return {
-    retrieve: createRemoteCacheRetrieve(safeImplementation),
-    store: createRemoteCacheStore(safeImplementation),
+    retrieve: createRemoteCacheRetrieve(safeImplementation, readDisabled),
+    store: createRemoteCacheStore(safeImplementation, writeDisabled),
   };
 };
 

--- a/lib/create-remote-cache-retrieve.ts
+++ b/lib/create-remote-cache-retrieve.ts
@@ -29,8 +29,12 @@ const writeCommitFile = (destination: string) => {
 };
 
 export const createRemoteCacheRetrieve = (
-  safeImplementation: Promise<SafeRemoteCacheImplementation | null>
+  safeImplementation: Promise<SafeRemoteCacheImplementation | null>,
+  disabled: boolean,
 ): RemoteCache["retrieve"] => async (hash, cacheDirectory) => {
+  if (disabled) {
+    return false;
+  }
   const implementation = await safeImplementation;
 
   if (!implementation) {

--- a/lib/create-remote-cache-store.ts
+++ b/lib/create-remote-cache-store.ts
@@ -8,8 +8,12 @@ const archiveFolder = (cwd: string, folder: string): Readable =>
   Readable.from(create({ gzip: true, C: cwd }, [folder]));
 
 export const createRemoteCacheStore = (
-  safeImplementation: Promise<SafeRemoteCacheImplementation | null>
+  safeImplementation: Promise<SafeRemoteCacheImplementation | null>,
+  disabled: boolean,
 ): RemoteCache["store"] => async (hash, cacheDirectory) => {
+  if (disabled) {
+    return false;
+  }
   const implementation = await safeImplementation;
 
   if (!implementation) {

--- a/lib/types/custom-runner-options.ts
+++ b/lib/types/custom-runner-options.ts
@@ -7,6 +7,12 @@ export type CustomRunnerOptions<T extends Object = Object> = T &
      */
     name?: string;
     /**
+     * Sets mode to enable/disable reads and/or writes to remote.
+     *
+     * @default read-write
+     */
+    mode?: "read-write" | "read-only" | "write-only" | "disabled";
+    /**
      * Sets verbose error logging for `nx-remotecache-custom`.
      */
     verbose?: boolean;


### PR DESCRIPTION
Introduce option for enabling/disabling read and/or writes to the remote cache. This can also be configured through environment variables.

This would enable easy configuration in usage scenarios for all remote caches based on this library.
- Only read from write constrained remote CI cache
- Have only protected branch write to remote cache
- Save data (pushing local builds) when working on hotspot, while benefiting from reading remote cache
- Disable remote cache(temporarily) without affecting local caching behaviour