### PR TITLE
Allow environment variables to have precedence over nx.json

### DIFF
--- a/lib/create-custom-runner.ts
+++ b/lib/create-custom-runner.ts
@@ -21,9 +21,9 @@ const createRemoteCache = (
   );
 
   const read = process.env.NXCACHE_READ ?
-    process.env.NXCACHE_READ !== "false" : (options.read || true);
+    process.env.NXCACHE_READ !== "false" : (options.read ?? true);
   const write = process.env.NXCACHE_WRITE ?
-    process.env.NXCACHE_WRITE !== "false" : (options.write || true);
+    process.env.NXCACHE_WRITE !== "false" : (options.write ?? true);
 
   if (options.verbose) {
     log.cacheCreated({ read, write });

--- a/lib/create-custom-runner.ts
+++ b/lib/create-custom-runner.ts
@@ -20,8 +20,10 @@ const createRemoteCache = (
     options
   );
 
-  const read = options.read ?? process.env.NXCACHE_READ !== "false";
-  const write = options.write ?? process.env.NXCACHE_WRITE !== "false";
+  const read = process.env.NXCACHE_READ ?
+    process.env.NXCACHE_READ !== "false" : (options.read || true);
+  const write = process.env.NXCACHE_WRITE ?
+    process.env.NXCACHE_WRITE !== "false" : (options.write || true);
 
   if (options.verbose) {
     log.cacheCreated({ read, write });

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/NiklasPor/nx-remotecache-custom#readme",
   "devDependencies": {
-    "@nx/workspace": "^16.0.1",
+    "@nx/workspace": "^16.5.1",
     "@types/tar": "^6.1.3",
     "@types/yargs": "^17.0.13",
     "typescript": "^4.1.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
 
 settings:
   autoInstallPeers: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
@@ -27,7 +27,7 @@ devDependencies:
     version: 17.0.24
   typescript:
     specifier: ^4.1.3
-    version: 4.1.3
+    version: 4.9.5
 
 packages:
 
@@ -1139,8 +1139,8 @@ packages:
     resolution: {integrity: sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==}
     dev: true
 
-  /typescript@4.1.3:
-    resolution: {integrity: sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==}
+  /typescript@4.9.5:
+    resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
     engines: {node: '>=4.2.0'}
     hasBin: true
     dev: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
@@ -17,8 +17,8 @@ dependencies:
 
 devDependencies:
   '@nx/workspace':
-    specifier: ^16.0.1
-    version: 16.1.3
+    specifier: ^16.5.1
+    version: 16.5.1
   '@types/tar':
     specifier: ^6.1.3
     version: 6.1.4
@@ -27,7 +27,7 @@ devDependencies:
     version: 17.0.24
   typescript:
     specifier: ^4.1.3
-    version: 4.9.5
+    version: 4.1.3
 
 packages:
 
@@ -52,51 +52,51 @@ packages:
       fastq: 1.15.0
     dev: true
 
-  /@nrwl/devkit@16.1.3(nx@16.1.3):
-    resolution: {integrity: sha512-gxbAWlqHh1xGoa1Zpf0gwLZ0jL7v1Zz/LF4HP1fBJiK6eaZmw5UzJKZWNX/VkDKppR9ZmQXCVTN8/u4FnmPB/w==}
+  /@nrwl/devkit@16.5.1(nx@16.5.1):
+    resolution: {integrity: sha512-NB+DE/+AFJ7lKH/WBFyatJEhcZGj25F24ncDkwjZ6MzEiSOGOJS0LaV/R+VUsmS5EHTPXYOpn3zHWWAcJhyOmA==}
     dependencies:
-      '@nx/devkit': 16.1.3(nx@16.1.3)
+      '@nx/devkit': 16.5.1(nx@16.5.1)
     transitivePeerDependencies:
       - nx
     dev: true
 
-  /@nrwl/tao@16.1.3:
-    resolution: {integrity: sha512-axt3o05V57rJaNOafu+8reHgo70idrccEd9X8jVgCyEDVixVsg5jzfw82/aeWVaQ2710VuGoruq0M81dUmzqyg==}
+  /@nrwl/tao@16.5.1:
+    resolution: {integrity: sha512-x+gi/fKdM6uQNIti9exFlm3V5LBP3Y8vOEziO42HdOigyrXa0S0HD2WMpccmp6PclYKhwEDUjKJ39xh5sdh4Ig==}
     hasBin: true
     dependencies:
-      nx: 16.1.3
+      nx: 16.5.1
     transitivePeerDependencies:
       - '@swc-node/register'
       - '@swc/core'
       - debug
     dev: true
 
-  /@nrwl/workspace@16.1.3:
-    resolution: {integrity: sha512-hyYTpnaIMRV7ihdzQFIDyon2SsN++EtRaEKwxZNMSIKCRaCZq1YArNUtkkBsDYmtwsJ+JPmZUfyZrovF+PBtBA==}
+  /@nrwl/workspace@16.5.1:
+    resolution: {integrity: sha512-+UvmdrrA887B8Una/grR9WXoM+LzejL5qOKqxSovVcTJ9X9Yr6RBxNMtpqRSq8e2bxi5TNqrgaRQ3+h0ED70JA==}
     dependencies:
-      '@nx/workspace': 16.1.3
+      '@nx/workspace': 16.5.1
     transitivePeerDependencies:
       - '@swc-node/register'
       - '@swc/core'
       - debug
     dev: true
 
-  /@nx/devkit@16.1.3(nx@16.1.3):
-    resolution: {integrity: sha512-FKKxvf27GXwhA10aBpI5u2IKhu/zXtI/74alPlwbYyLqxJl7NTGeCnOWzhnapE10bSs89TI7b2n2HI+hwz6Neg==}
+  /@nx/devkit@16.5.1(nx@16.5.1):
+    resolution: {integrity: sha512-T1acZrVVmJw/sJ4PIGidCBYBiBqlg/jT9e8nIGXLSDS20xcLvfo4zBQf8UZLrmHglnwwpDpOWuVJCp2rYA5aDg==}
     peerDependencies:
       nx: '>= 15 <= 17'
     dependencies:
-      '@nrwl/devkit': 16.1.3(nx@16.1.3)
+      '@nrwl/devkit': 16.5.1(nx@16.5.1)
       ejs: 3.1.9
       ignore: 5.2.4
-      nx: 16.1.3
-      semver: 7.3.4
+      nx: 16.5.1
+      semver: 7.5.3
       tmp: 0.2.1
       tslib: 2.5.0
     dev: true
 
-  /@nx/nx-darwin-arm64@16.1.3:
-    resolution: {integrity: sha512-Q7o9mmu20nwaVHB6lwUvXJxFYbjElb0/L79EpmEH9x/ZHST0XmpXUJVi1sGHUy2cD3NFgm1/T9DUTXxxNc+1nQ==}
+  /@nx/nx-darwin-arm64@16.5.1:
+    resolution: {integrity: sha512-q98TFI4B/9N9PmKUr1jcbtD4yAFs1HfYd9jUXXTQOlfO9SbDjnrYJgZ4Fp9rMNfrBhgIQ4x1qx0AukZccKmH9Q==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
@@ -104,8 +104,8 @@ packages:
     dev: true
     optional: true
 
-  /@nx/nx-darwin-x64@16.1.3:
-    resolution: {integrity: sha512-AL1hXnDinwfOE2d4j6FwRg2wVDdSDAbNiFEnaTrjnd53rIj2RpohhasImdRJ9jS3ixzqGLVncR28rK8kq3lqIQ==}
+  /@nx/nx-darwin-x64@16.5.1:
+    resolution: {integrity: sha512-j9HmL1l8k7EVJ3eOM5y8COF93gqrydpxCDoz23ZEtsY+JHY77VAiRQsmqBgEx9GGA2dXi9VEdS67B0+1vKariw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
@@ -113,8 +113,17 @@ packages:
     dev: true
     optional: true
 
-  /@nx/nx-linux-arm-gnueabihf@16.1.3:
-    resolution: {integrity: sha512-8/7GzisyKdrqFNCjMqb2iKWDkaYS+MMoz1/BisaDcPn9nGiGrdibUuu4eBLf2l80Qk5vm0mxOPfJq1UQ211SZA==}
+  /@nx/nx-freebsd-x64@16.5.1:
+    resolution: {integrity: sha512-CXSPT01aVS869tvCCF2tZ7LnCa8l41wJ3mTVtWBkjmRde68E5Up093hklRMyXb3kfiDYlfIKWGwrV4r0eH6x1A==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@nx/nx-linux-arm-gnueabihf@16.5.1:
+    resolution: {integrity: sha512-BhrumqJSZCWFfLFUKl4CAUwR0Y0G2H5EfFVGKivVecEQbb+INAek1aa6c89evg2/OvetQYsJ+51QknskwqvLsA==}
     engines: {node: '>= 10'}
     cpu: [arm]
     os: [linux]
@@ -122,8 +131,8 @@ packages:
     dev: true
     optional: true
 
-  /@nx/nx-linux-arm64-gnu@16.1.3:
-    resolution: {integrity: sha512-vT+hNbCV61xLRVQqevwb0/hAN0nZ6Hlp5ydOMLP4cqqPHcbGprNXYLenv6ZM+pPM8S0HtIxnzSRA+zHRoQNgFw==}
+  /@nx/nx-linux-arm64-gnu@16.5.1:
+    resolution: {integrity: sha512-x7MsSG0W+X43WVv7JhiSq2eKvH2suNKdlUHEG09Yt0vm3z0bhtym1UCMUg3IUAK7jy9hhLeDaFVFkC6zo+H/XQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -131,8 +140,8 @@ packages:
     dev: true
     optional: true
 
-  /@nx/nx-linux-arm64-musl@16.1.3:
-    resolution: {integrity: sha512-D6+WGqPeGK+5oqv7jNHP7EKtY35dNM7EQmhMuwWFWPIBU7z2O63USWC8lIiijAVc9SPOGa04jVe+ynaTROaLQQ==}
+  /@nx/nx-linux-arm64-musl@16.5.1:
+    resolution: {integrity: sha512-J+/v/mFjOm74I0PNtH5Ka+fDd+/dWbKhpcZ2R1/6b9agzZk+Ff/SrwJcSYFXXWKbPX+uQ4RcJoytT06Zs3s0ow==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -140,8 +149,8 @@ packages:
     dev: true
     optional: true
 
-  /@nx/nx-linux-x64-gnu@16.1.3:
-    resolution: {integrity: sha512-gMHVX3fpOc0aFsoc7w00/YpyBp1KGWoB/Mu91yBWwXG6E2o/v+j3rOq1VVsY3byv3M+PjItSE9O6yG8D5KdqQA==}
+  /@nx/nx-linux-x64-gnu@16.5.1:
+    resolution: {integrity: sha512-igooWJ5YxQ94Zft7IqgL+Lw0qHaY15Btw4gfK756g/YTYLZEt4tTvR1y6RnK/wdpE3sa68bFTLVBNCGTyiTiDQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -149,8 +158,8 @@ packages:
     dev: true
     optional: true
 
-  /@nx/nx-linux-x64-musl@16.1.3:
-    resolution: {integrity: sha512-s8fnKjpwVNjZsaxu0oBTb5Epqu4pYpS+BM1VvM0mvmABpFnItlkyhLnVzy8UVBNAgJIw8eNyawshUcp0YB3pCw==}
+  /@nx/nx-linux-x64-musl@16.5.1:
+    resolution: {integrity: sha512-zF/exnPqFYbrLAduGhTmZ7zNEyADid2bzNQiIjJkh8Y6NpDwrQIwVIyvIxqynsjMrIs51kBH+8TUjKjj2Jgf5A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -158,8 +167,8 @@ packages:
     dev: true
     optional: true
 
-  /@nx/nx-win32-arm64-msvc@16.1.3:
-    resolution: {integrity: sha512-vCa+aUbP4yq5Gi55Q4jqezGQ5iDSBaPc8A0Gs5JWdFPapoFljZrz4IVmb2I7c6UccALFdt0pz9rODUqxQPCZ7g==}
+  /@nx/nx-win32-arm64-msvc@16.5.1:
+    resolution: {integrity: sha512-qtqiLS9Y9TYyAbbpq58kRoOroko4ZXg5oWVqIWFHoxc5bGPweQSJCROEqd1AOl2ZDC6BxfuVHfhDDop1kK05WA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
@@ -167,8 +176,8 @@ packages:
     dev: true
     optional: true
 
-  /@nx/nx-win32-x64-msvc@16.1.3:
-    resolution: {integrity: sha512-5H6KPkrjMJ3PPJGEl0ImmUYZ5dd9sXovOyzsEdaLQTo2u3UCy9+mQQJJ6dfTGDfpBXDXSJfykutM1D0nlVP83A==}
+  /@nx/nx-win32-x64-msvc@16.5.1:
+    resolution: {integrity: sha512-kUJBLakK7iyA9WfsGGQBVennA4jwf5XIgm0lu35oMOphtZIluvzItMt0EYBmylEROpmpEIhHq0P6J9FA+WH0Rg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -176,11 +185,11 @@ packages:
     dev: true
     optional: true
 
-  /@nx/workspace@16.1.3:
-    resolution: {integrity: sha512-WZ10B69/ug5GjVdZt1DIDOxpmHM//8Y3nMTl6gH4jKVDtdRxMUT23EqXgQfkII0dXW0164oxpJb9nyUuS3Mytg==}
+  /@nx/workspace@16.5.1:
+    resolution: {integrity: sha512-xzibe6Nm2hyyM2kJ1NSL9RnVoVgktd5wQ2XLk5/9z/5a2bXjce48eYNvg3oo2U4O75FndG9pcuGsKXtejsbaSA==}
     dependencies:
-      '@nrwl/workspace': 16.1.3
-      '@nx/devkit': 16.1.3(nx@16.1.3)
+      '@nrwl/workspace': 16.5.1
+      '@nx/devkit': 16.5.1(nx@16.5.1)
       '@parcel/watcher': 2.0.4
       chalk: 4.1.2
       chokidar: 3.5.3
@@ -192,7 +201,7 @@ packages:
       ignore: 5.2.4
       minimatch: 3.0.5
       npm-run-path: 4.0.1
-      nx: 16.1.3
+      nx: 16.5.1
       open: 8.4.2
       rxjs: 7.8.1
       tmp: 0.2.1
@@ -239,8 +248,8 @@ packages:
     resolution: {integrity: sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==}
     dev: true
 
-  /@yarnpkg/parsers@3.0.0-rc.43:
-    resolution: {integrity: sha512-AhFF3mIDfA+jEwQv2WMHmiYhOvmdbh2qhUkDVQfiqzQtUwS4BgoWwom5NpSPg4Ix5vOul+w1690Bt21CkVLpgg==}
+  /@yarnpkg/parsers@3.0.0-rc.46:
+    resolution: {integrity: sha512-aiATs7pSutzda/rq8fnuPwTglyVwjM22bNnK2ZgjrpAjQHSSl3lztd2f9evst1W/qnC58DRz7T7QndUDumAR4Q==}
     engines: {node: '>=14.15.0'}
     dependencies:
       js-yaml: 3.14.1
@@ -606,7 +615,7 @@ packages:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 3.0.5
+      minimatch: 3.1.2
       once: 1.4.0
       path-is-absolute: 1.0.1
     dev: true
@@ -700,7 +709,7 @@ packages:
       async: 3.2.4
       chalk: 4.1.2
       filelist: 1.0.4
-      minimatch: 3.0.5
+      minimatch: 3.1.2
     dev: true
 
   /js-yaml@3.14.1:
@@ -853,8 +862,8 @@ packages:
       path-key: 3.1.1
     dev: true
 
-  /nx@16.1.3:
-    resolution: {integrity: sha512-sLI0VvdMSKLk8B7+05ho58Bh3v7a7UvdIvQI1ITgZLn6phWvo9gDHc7ZP2MsFgdDjSNVDigqwi6ebCDpMErPMw==}
+  /nx@16.5.1:
+    resolution: {integrity: sha512-I3hJRE4hG7JWAtncWwDEO3GVeGPpN0TtM8xH5ArZXyDuVeTth/i3TtJzdDzqXO1HHtIoAQN0xeq4n9cLuMil5g==}
     hasBin: true
     requiresBuild: true
     peerDependencies:
@@ -866,10 +875,10 @@ packages:
       '@swc/core':
         optional: true
     dependencies:
-      '@nrwl/tao': 16.1.3
+      '@nrwl/tao': 16.5.1
       '@parcel/watcher': 2.0.4
       '@yarnpkg/lockfile': 1.1.0
-      '@yarnpkg/parsers': 3.0.0-rc.43
+      '@yarnpkg/parsers': 3.0.0-rc.46
       '@zkochan/js-yaml': 0.0.6
       axios: 1.4.0
       chalk: 4.1.2
@@ -890,7 +899,7 @@ packages:
       minimatch: 3.0.5
       npm-run-path: 4.0.1
       open: 8.4.2
-      semver: 7.3.4
+      semver: 7.5.3
       string-width: 4.2.3
       strong-log-transformer: 2.1.0
       tar-stream: 2.2.0
@@ -901,15 +910,16 @@ packages:
       yargs: 17.7.2
       yargs-parser: 21.1.1
     optionalDependencies:
-      '@nx/nx-darwin-arm64': 16.1.3
-      '@nx/nx-darwin-x64': 16.1.3
-      '@nx/nx-linux-arm-gnueabihf': 16.1.3
-      '@nx/nx-linux-arm64-gnu': 16.1.3
-      '@nx/nx-linux-arm64-musl': 16.1.3
-      '@nx/nx-linux-x64-gnu': 16.1.3
-      '@nx/nx-linux-x64-musl': 16.1.3
-      '@nx/nx-win32-arm64-msvc': 16.1.3
-      '@nx/nx-win32-x64-msvc': 16.1.3
+      '@nx/nx-darwin-arm64': 16.5.1
+      '@nx/nx-darwin-x64': 16.5.1
+      '@nx/nx-freebsd-x64': 16.5.1
+      '@nx/nx-linux-arm-gnueabihf': 16.5.1
+      '@nx/nx-linux-arm64-gnu': 16.5.1
+      '@nx/nx-linux-arm64-musl': 16.5.1
+      '@nx/nx-linux-x64-gnu': 16.5.1
+      '@nx/nx-linux-x64-musl': 16.5.1
+      '@nx/nx-win32-arm64-msvc': 16.5.1
+      '@nx/nx-win32-x64-msvc': 16.5.1
     transitivePeerDependencies:
       - debug
     dev: true
@@ -1016,8 +1026,8 @@ packages:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
     dev: true
 
-  /semver@7.3.4:
-    resolution: {integrity: sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==}
+  /semver@7.5.3:
+    resolution: {integrity: sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==}
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
@@ -1129,8 +1139,8 @@ packages:
     resolution: {integrity: sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==}
     dev: true
 
-  /typescript@4.9.5:
-    resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
+  /typescript@4.1.3:
+    resolution: {integrity: sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==}
     engines: {node: '>=4.2.0'}
     hasBin: true
     dev: true


### PR DESCRIPTION
Hello @NiklasPor, thanks for creating this awesome library and merging https://github.com/NiklasPor/nx-remotecache-custom/pull/12 .

There are 2 current issues with the library 
1. Not compatible with Nx 16.5.1 -> Solution update "@nx/workspace" to"^16.5.1" and everything just works

2. The new read/write toggles are not easy to override
I wanted to enable reads for everyone and writes only on CI.
My first idea was to set `read=true` and  `write=false` in the `nx json` and set the the env variable NXCACHE_WRITE=true on CI.
However the current code prioritises the `nx.json` over the the environment variables.

This PR is meant to address both of these issues.