### PR TITLE
wrap stream in Readable.from() to avoid Problems with node v18.17.0

### DIFF
--- a/lib/create-remote-cache-retrieve.ts
+++ b/lib/create-remote-cache-retrieve.ts
@@ -2,6 +2,7 @@ import { RemoteCache } from "@nx/workspace/src/tasks-runner/default-tasks-runner
 import { mkdir, writeFile } from "fs/promises";
 import { join } from "path";
 import { pipeline } from "stream/promises";
+import { Readable } from "stream";
 import { extract } from "tar";
 import { getFileNameFromHash } from "./get-file-name-from-hash";
 import { SafeRemoteCacheImplementation } from "./types/safe-remote-cache-implementation";
@@ -15,7 +16,7 @@ const extractFolder = async (
 ) => {
   await mkdir(destination, { recursive: true });
   return await pipeline(
-    stream,
+    Readable.from(stream),
     extract({
       C: destination,
       strip: 1,


### PR DESCRIPTION
Sometimes, with node v18 there are problems like `zlib: unexpected end of file`. Wrapping the incoming stream into `Readable.from()` avoids this problem.
