### PR TITLE
Support Nx 16.6.0 (prevent storing and retrieving machine id)

### DIFF
--- a/lib/create-remote-cache-retrieve.ts
+++ b/lib/create-remote-cache-retrieve.ts
@@ -5,6 +5,7 @@ import { pipeline } from "stream/promises";
 import { extract } from "tar";
 import { getFileNameFromHash } from "./get-file-name-from-hash";
 import { SafeRemoteCacheImplementation } from "./types/safe-remote-cache-implementation";
+import { filterMachineId } from "./filter-machine-id";
 
 const COMMIT_FILE_EXTENSION = ".commit";
 const COMMIT_FILE_CONTENT = "true";
@@ -19,6 +20,7 @@ const extractFolder = async (
     extract({
       C: destination,
       strip: 1,
+      filter: filterMachineId
     })
   );
 };

--- a/lib/create-remote-cache-store.ts
+++ b/lib/create-remote-cache-store.ts
@@ -3,9 +3,10 @@ import { Readable } from "stream";
 import { create } from "tar";
 import { getFileNameFromHash } from "./get-file-name-from-hash";
 import { SafeRemoteCacheImplementation } from "./types/safe-remote-cache-implementation";
+import { filterMachineId } from "./filter-machine-id";
 
 const archiveFolder = (cwd: string, folder: string): Readable =>
-  Readable.from(create({ gzip: true, C: cwd }, [folder]));
+  Readable.from(create({ gzip: true, C: cwd, filter: filterMachineId }, [folder]));
 
 export const createRemoteCacheStore = (
   safeImplementation: Promise<SafeRemoteCacheImplementation | null>

--- a/lib/filter-machine-id.ts
+++ b/lib/filter-machine-id.ts
@@ -1,0 +1,3 @@
+export function filterMachineId(path: string) {
+  return !path.endsWith('/source');
+}


### PR DESCRIPTION
In Nx 16.6.0 they introduced a check for a local machine id which triggers an error if a cache is found with a mismatched machine id: https://github.com/nrwl/nx/pull/18057
This causes every task to fail with an error like this if the cache was built on another machine (for example CI):
```
>  NX   Invalid Cache Directory for Task "project:build"

   The local cache artifact in "/Users/user/project/node_modules/.cache/nx/14108599593977399945" was not been generated on this machine.
   As a result, the cache's content integrity cannot be confirmed, which may make cache restoration potentially unsafe.
   If your machine ID has changed since the artifact was cached, run "nx reset" to fix this issue.
   Read about the error and how to address it here: https://nx.dev/recipes/troubleshooting/unknown-local-cache
   
   Pass --verbose to see the stacktrace.
```

Luckily it is enough to filter the newly created `source` file which is stored inside the cache. If this file doesn't exist the integrity check succeeds. I'm pretty sure they are also filtering it for their Nx cloud cache implementation.