### PR TITLE
fix filter-source-file to work OS independently

### DIFF
--- a/lib/create-filter-source-file.ts
+++ b/lib/create-filter-source-file.ts
@@ -1,5 +1,5 @@
-import { join } from "path";
+import { join, normalize } from "path";
 
 export function createFilterSourceFile(hash: string) {
-  return (path: string) => path !== join(hash, "source");
+  return (path: string) => normalize(path) !== join(hash, "source");
 }


### PR DESCRIPTION
On Windows, the `createFilterSourceFile` function doesn't work, because of different path separators.
Use path.normalize to make the paths comparable.

If you accept this PR, would you please release a new version of the nx-remotecache-minio?
Thank you!